### PR TITLE
Add OpenAI image generation endpoint

### DIFF
--- a/Controllers/ImageController.cs
+++ b/Controllers/ImageController.cs
@@ -1,5 +1,6 @@
 ﻿using db_query_v1._0._0._1.Services;
 using Microsoft.AspNetCore.Mvc;
+using db_query_v1._0._0._1.Models;
 
 namespace db_query_v1._0._0._1.Controllers
 {
@@ -9,11 +10,15 @@ namespace db_query_v1._0._0._1.Controllers
     {
         private readonly OcrService _ocrService;
         private readonly ChatGptService _chatGptService;
+        private readonly ImageGenerationService _imageGenerationService;
 
-        public ImageController(OcrService ocrService, ChatGptService chatGptService)
+        public ImageController(OcrService ocrService,
+                               ChatGptService chatGptService,
+                               ImageGenerationService imageGenerationService)
         {
             _ocrService = ocrService;
             _chatGptService = chatGptService;
+            _imageGenerationService = imageGenerationService;
         }
 
         [HttpPost("extract-and-process")]
@@ -45,6 +50,18 @@ namespace db_query_v1._0._0._1.Controllers
                 ExtractedText = extractedText,
                 ChatGptResponse = chatGptResponse
             });
+        }
+
+        [HttpPost("generate-from-prompt")]
+        public async Task<IActionResult> GenerateFromPrompt([FromBody] ImagePrompt request)
+        {
+            if (string.IsNullOrWhiteSpace(request?.Prompt))
+            {
+                return BadRequest("Prompt is required.");
+            }
+
+            var imageUrl = await _imageGenerationService.GenerateImageAsync(request.Prompt);
+            return Ok(new { ImageUrl = imageUrl });
         }
     }
 }

--- a/Models/ImagePrompt.cs
+++ b/Models/ImagePrompt.cs
@@ -1,0 +1,7 @@
+namespace db_query_v1._0._0._1.Models
+{
+    public class ImagePrompt
+    {
+        public string Prompt { get; set; }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -59,6 +59,10 @@ namespace db_query_v1._0._0._1
             builder.Services.AddSingleton(sp => new ChatGptService(
                 sp.GetRequiredService<HttpClient>(),
                 builder.Configuration["OPENAI_API_KEY"]));
+            builder.Services.AddHttpClient<ImageGenerationService>();
+            builder.Services.AddSingleton(sp => new ImageGenerationService(
+                sp.GetRequiredService<HttpClient>(),
+                builder.Configuration["OPENAI_API_KEY"]));
 
             // MVC & API
             builder.Services.AddControllersWithViews();

--- a/Services/ImageGenerationService.cs
+++ b/Services/ImageGenerationService.cs
@@ -1,0 +1,45 @@
+using System.Net.Http.Json;
+using System.Net.Http.Headers;
+
+namespace db_query_v1._0._0._1.Services
+{
+    public class ImageGenerationService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly string _apiKey;
+
+        public ImageGenerationService(HttpClient httpClient, string apiKey)
+        {
+            _httpClient = httpClient;
+            _apiKey = apiKey;
+        }
+
+        public async Task<string> GenerateImageAsync(string prompt)
+        {
+            var requestBody = new
+            {
+                prompt = prompt,
+                n = 1,
+                size = "512x512"
+            };
+
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+
+            var response = await _httpClient.PostAsJsonAsync("https://api.openai.com/v1/images/generations", requestBody);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadFromJsonAsync<DallEResponse>();
+            return result?.Data?.FirstOrDefault()?.Url ?? string.Empty;
+        }
+
+        private class DallEResponse
+        {
+            public List<ImageData> Data { get; set; }
+        }
+
+        private class ImageData
+        {
+            public string Url { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ImageGenerationService` for DALL·E requests
- add `ImagePrompt` model
- extend `ImageController` with `generate-from-prompt` API
- register `ImageGenerationService` in `Program.cs`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423729e9c08323857c952783adaf1f